### PR TITLE
Rewrite with synchronous and asynchronous mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ require('mason-update-all').setup()
 ```
 
 ## Commands
-- `:MasonUpdateAll` — update all installed Mason packages
+- `:MasonUpdateAll` — update all installed Mason packages in asynchronous mode. Mason installation runs in background.
+- `:MasonUpdateAllSync` — update all installed Mason packages in synchronous mode. Will run installation of all packages asynchronously but will not end until all of them finish installing. Useful for `--headless` run.
 
 ## Events
-Upon completion of all updates the user event `MasonUpdateAllComplete` will be emitted. You can use it like so:
+Upon completion of all updates the user event `MasonUpdateAllComplete` will be emitted. This will work only with `MasonUpdateAllSync`. You can use it like so:
 
 ```lua
 vim.api.nvim_create_autocmd('User', {
@@ -58,6 +59,6 @@ Using the provided vim command and user event, it is possible to update the Maso
 # Update Packer plugins
 nvim --headless -c 'autocmd User PackerComplete quitall' -c 'PackerSync'
 
-# Update Mason packages
-nvim --headless -c 'autocmd User MasonUpdateAllComplete quitall' -c 'MasonUpdateAll'
+# Update Mason packages synchronously
+nvim --headless -c 'autocmd User MasonUpdateAllComplete quitall' -c 'MasonUpdateAllSync'
 ```

--- a/lua/mason-update-all/init.lua
+++ b/lua/mason-update-all/init.lua
@@ -2,35 +2,37 @@ local registry = require('mason-registry')
 
 local M = {}
 
-local function check_done(running_count, any_update)
-    if running_count == 0 then
-        if any_update then
-            print('[mason-update-all] Finished updating all packages')
-        else
-            print('[mason-update-all] Nothing to update')
-        end
+local function check_installed(pkg)
+    local installed = false
+    local install_counter = 0
 
-        -- Trigger autocmd
-        vim.schedule(function()
-            vim.api.nvim_exec_autocmds('User', {
-                pattern = 'MasonUpdateAllComplete',
-            })
+    -- Check if installation still running
+    repeat
+        install_counter = install_counter + 1
+        pkg:check_new_version(function(new, _)
+            if new then
+                installed = false
+                vim.wait(2000, function() end)
+            else
+                installed = true
+            end
         end)
-    end
+    until installed == true or install_counter >= 10
 end
 
-function M.update_all()
+local function update_all(sync)
     local any_update = false -- Whether any package was updated
-    local running_count = 0 -- Currently running jobs
+    local update_list = {} -- list of pacakges to udpate
 
     print('[mason-update-all] Fetching updates')
+
     -- Iterate installed packages
     for _, pkg in ipairs(registry.get_installed_packages()) do
-        running_count = running_count + 1
 
         -- Fetch for new version
         pkg:check_new_version(function(new_available, version)
             if new_available then
+                table.insert(update_list, pkg)
                 any_update = true
                 print(
                     ('[mason-update-all] Updating %s from %s to %s'):format(
@@ -39,25 +41,47 @@ function M.update_all()
                         version.latest_version
                     )
                 )
-                pkg:install():on('closed', function()
-                    running_count = running_count - 1
-                    print(('[mason-update-all] Updated %s to %s'):format(pkg.name, version.latest_version))
-
-                    -- Done
-                    check_done(running_count, any_update)
-                end)
-            else
-                running_count = running_count - 1
+                pkg:install()
             end
-
-            -- Done
-            check_done(running_count, any_update)
         end)
+    end
+
+    -- Verify packages finished installation in async mode
+    if sync then
+        for _,pkg in ipairs(update_list) do
+            check_installed(pkg)
+            print(('[mason-update-all] Updated %s'):format(pkg.name))
+        end
+    end
+
+    -- Done
+    if any_update then
+        print('[mason-update-all] Finished updating all packages')
+    else
+        print('[mason-update-all] Nothing to update')
+    end
+
+    -- Trigger autocmd for async mode
+    if sync then
+      vim.schedule(function()
+          vim.api.nvim_exec_autocmds('User', {
+              pattern = 'MasonUpdateAllComplete',
+          })
+      end)
     end
 end
 
+function M.update_async()
+    update_all(false)
+end
+
+function M.update_sync()
+    update_all(true)
+end
+
 function M.setup()
-    vim.api.nvim_create_user_command('MasonUpdateAll', M.update_all, {})
+    vim.api.nvim_create_user_command('MasonUpdateAll', M.update_async, {})
+    vim.api.nvim_create_user_command('MasonUpdateAllSync', M.update_sync, {})
 end
 
 return M


### PR DESCRIPTION
This actually address few issues I found. 

1. Headless mode not working properly. Headless will require sync run so `MasonUpdateAllComplete` emits when all is updated.
2. Lots of messages `[mason-update-all] Nothing to update` for each installed package. With this change it will print only once.
3. Async mode still supported when run in UI.