### PR TITLE
Fix E5560 during package pdates

### DIFF
--- a/lua/mason-update-all/init.lua
+++ b/lua/mason-update-all/init.lua
@@ -2,17 +2,15 @@ local registry = require('mason-registry')
 
 local M = {}
 
--- Detect whether we're running in headless mode
-local function is_headless()
-    return #vim.api.nvim_list_uis() == 0
-end
+-- Cache headless mode at startup to avoid unsafe calls inside event loop
+local IS_HEADLESS = #vim.api.nvim_list_uis() == 0
 
 -- Smart message printer:
 -- - uses io.stdout in headless mode for clean CLI output
 -- - uses vim.notify in interactive mode if available
 -- - falls back to print() otherwise
 local function print_message(message)
-    if is_headless() then
+    if IS_HEADLESS then
         io.stdout:write('[mason-update-all]' .. message .. '\n')
     elseif vim.notify then
         vim.notify(message, vim.log.levels.INFO, { title = 'Mason Update All' })


### PR DESCRIPTION
Neovim throws E5560 when `vim.api.nvim_list_uis()` is called from within a loop callback or scheduled function.

This PR moves the headless check into a constant so it is computed once at load time. This avoids runtime errors in `vim.schedule` context.

Tested with multiple package updates to confirm CLI and interactive modes both behave correctly.