### PR TITLE
BUGFIX : mason.nvim v2.0.0 changed check_new_version to get_latest_version call

### DIFF
--- a/lua/mason-update-all/init.lua
+++ b/lua/mason-update-all/init.lua
@@ -62,28 +62,28 @@ function M.update_all()
             running_count = running_count + 1
 
             -- Fetch for new version
-            pkg:check_new_version(function(new_available, version)
-                if new_available then
-                    any_update = true
-                    print_message(
-                        ('Updating %s from %s to %s'):format(pkg.name, version.current_version, version.latest_version)
-                    )
-                    pkg:install():on('closed', function()
-                        running_count = running_count - 1
-                        print_message(('Updated %s to %s'):format(pkg.name, version.latest_version))
-
-                        -- Done
-                        check_done(running_count, any_update)
-                    end)
-                else
+            local latest_version = pkg:get_latest_version()
+            local current_version = pkg:get_installed_version()
+            if current_version ~= latest_version then
+                any_update = true
+                print_message(
+                    ('Updating %s from %s to %s'):format(pkg.name, current_version, latest_version)
+                )
+                pkg:install():on('closed', function()
                     running_count = running_count - 1
-                end
+                    print_message(('Updated %s to %s'):format(pkg.name, latest_version))
 
-                -- Done
-                if done_launching_jobs then
+                    -- Done
                     check_done(running_count, any_update)
-                end
-            end)
+                end)
+            else
+                running_count = running_count - 1
+            end
+
+            -- Done
+            if done_launching_jobs then
+                check_done(running_count, any_update)
+            end
         end
 
         -- If all jobs are immediately done, do the checking here


### PR DESCRIPTION
The new version of mason.nvim ([v2.0.0 release tag](https://github.com/mason-org/mason.nvim/releases/tag/v2.0.0)) removed `Package:check_new_version()` from its API as stated in the "Package API changes" of the changelog :

> Package:check_new_version() has been removed.
>
> Breaking Change
>
> Package:check_new_version() is replaced by Package:get_latest_version().  Package:get_latest_version() is a
> synchronous API.

**This change currently breaks the module** upon calling the `MasonUpdateAll` command.

This pull request aims to fix this by changing the call to the new `Package:get_latest_version()`, albeit the change is minimal, the fetching of the new version is now synchronous, which can be changed within the module if need be. That noted, the installation of the package stays asynchronous.

Cheers