### PR TITLE
Fix nil opts error during plugin setup

### DIFF
--- a/lua/mason-update-all/init.lua
+++ b/lua/mason-update-all/init.lua
@@ -106,6 +106,7 @@ end
 
 ---@param opts MasonUpdateAllSettings
 function M.setup(opts)
+    opts = opts or {}
     M.current = vim.tbl_deep_extend('force', M.current, opts)
     vim.api.nvim_create_user_command('MasonUpdateAll', M.update_all, {})
 end


### PR DESCRIPTION
The plugin fails to initialize when no configuration options are provided, causing `vim.tbl_deep_extend` to throw an error due to a nil value.

This fix ensures that `opts` is initialized as an empty table when nil, allowing the plugin to setup correctly with default settings when no options are passed.